### PR TITLE
Fix: AttributeError in determine_clipboard()

### DIFF
--- a/src/pyperclipfix/__init__.py
+++ b/src/pyperclipfix/__init__.py
@@ -537,15 +537,21 @@ def determine_clipboard():
         else:
             return init_osx_pyobjc_clipboard()
 
-    # For GNOME
-    if 'gnome' in os.getenv('XDG_CURRENT_DESKTOP').lower() \
-            and _executable_exists("gpaste-client"):
-        return init_gpaste_clipboard()
+    # Bug: When os.getenv returns None, .lower() will raise AttributeError
+    # Fix: Only proceed if None is not returned
 
-    # For KDE
-    if 'kde' in os.getenv('XDG_CURRENT_DESKTOP').lower() \
-            and _executable_exists("klipper") and _executable_exists("qdbus"):
-        return init_klipper_clipboard()
+    xdg_current_desktop = os.getenv('XDG_CURRENT_DESKTOP')
+
+    if xdg_current_desktop is not None:
+        # For GNOME
+        if 'gnome' in xdg_current_desktop.lower() \
+                and _executable_exists("gpaste-client"):
+            return init_gpaste_clipboard()
+
+        # For KDE
+        if 'kde' in xdg_current_desktop.lower() \
+                and _executable_exists("klipper") and _executable_exists("qdbus"):
+            return init_klipper_clipboard()
 
     # For wayland (generic):
     if (os.environ.get("WAYLAND_DISPLAY") and _executable_exists("wl-copy")):


### PR DESCRIPTION
Fix: `AttributeError` in `determine_clipboard()` when `'XDG_CURRENT_DESKTOP'` is `None`.

Change conditional check for `os.getenv('XDG_CURRENT_DESKTOP').lower()` to avoid `AttributeError` when `os.getenv()` returns a default value of `None`. Only proceed with checking for `'gnome'` and `'kde'` in `XDG_CURRENT_DESKTOP` environment variable, if the value returned by `os.getenv()` is not `None`.

Note: Tested only on an environment with no value set for 'XDG_CURRENT_DESKTOP'. See the following output:

```
>>> pyperclipfix.determine_clipboard()
(<function init_xsel_clipboard.<locals>.copy_xsel at 0x7f6ded5c8220>, <function init_xsel_clipboard.<locals>.paste_xsel at 0x7f6ded57bec0>)
```

Ref: [Python Docs - os.getenv](https://docs.python.org/3/library/os.html#os.getenv)